### PR TITLE
Add DFS maze generator and terminal-playable maze

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,48 @@
 # maze-generator
-Maze generation experiments
+
+Maze generation experiments.
+
+## Algorithm implemented
+
+This repository includes a maze generator based on **recursive backtracking**
+(depth-first search using an explicit stack):
+
+1. Initialize a 2D grid of cells.
+2. Each cell starts with four walls (`top`, `right`, `bottom`, `left`) and `visited=False`.
+3. Pick a random starting cell and mark it visited.
+4. While the stack is not empty:
+   - Find unvisited neighbors of the current cell.
+   - If neighbors exist, pick one at random, remove the shared wall,
+     mark the neighbor visited, and push it.
+   - Otherwise, pop from the stack to backtrack.
+5. Return the final grid as a matrix of wall flags.
+
+## Usage
+
+### 1) Generate wall data
+
+```bash
+python maze_generator.py
+```
+
+Or import from Python:
+
+```python
+from maze_generator import generate_maze, maze_to_wall_matrix
+
+grid = generate_maze(rows=10, cols=10, seed=123)
+matrix = maze_to_wall_matrix(grid)
+```
+
+### 2) Play the maze in terminal
+
+```bash
+python playable_maze.py
+```
+
+Controls:
+- `W` / `A` / `S` / `D` (or `up` / `left` / `down` / `right`) to move.
+- `Q` to quit.
+
+Goal:
+- Start at `P` and reach `G`.

--- a/maze_generator.py
+++ b/maze_generator.py
@@ -1,0 +1,128 @@
+"""Maze generator using recursive backtracking (depth-first search with a stack)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from random import Random
+from typing import List
+
+
+@dataclass
+class Cell:
+    """A maze cell with walls on each side and a visited flag."""
+
+    top: bool = True
+    right: bool = True
+    bottom: bool = True
+    left: bool = True
+    visited: bool = False
+
+
+Grid = List[List[Cell]]
+
+
+def _unvisited_neighbors(grid: Grid, row: int, col: int) -> list[tuple[int, int, str]]:
+    """Return unvisited neighboring cells and their relative direction from (row, col)."""
+
+    rows = len(grid)
+    cols = len(grid[0]) if rows else 0
+    neighbors: list[tuple[int, int, str]] = []
+
+    candidates = [
+        (row - 1, col, "top"),
+        (row, col + 1, "right"),
+        (row + 1, col, "bottom"),
+        (row, col - 1, "left"),
+    ]
+
+    for nr, nc, direction in candidates:
+        if 0 <= nr < rows and 0 <= nc < cols and not grid[nr][nc].visited:
+            neighbors.append((nr, nc, direction))
+
+    return neighbors
+
+
+def _remove_wall_between(current: Cell, neighbor: Cell, direction: str) -> None:
+    """Remove walls between current cell and a selected neighbor."""
+
+    if direction == "top":
+        current.top = False
+        neighbor.bottom = False
+    elif direction == "right":
+        current.right = False
+        neighbor.left = False
+    elif direction == "bottom":
+        current.bottom = False
+        neighbor.top = False
+    elif direction == "left":
+        current.left = False
+        neighbor.right = False
+    else:
+        raise ValueError(f"Unsupported direction: {direction}")
+
+
+def generate_maze(rows: int, cols: int, seed: int | None = None) -> Grid:
+    """Generate a maze with DFS backtracking and return the grid of cells.
+
+    The returned structure is a 2D matrix where each cell keeps:
+    - wall booleans: top/right/bottom/left
+    - visited flag
+    """
+
+    if rows <= 0 or cols <= 0:
+        raise ValueError("rows and cols must both be > 0")
+
+    rng = Random(seed)
+    grid: Grid = [[Cell() for _ in range(cols)] for _ in range(rows)]
+
+    # 1) Choose random starting cell and mark it as visited.
+    current_row = rng.randrange(rows)
+    current_col = rng.randrange(cols)
+    grid[current_row][current_col].visited = True
+
+    # 2) Process cells via stack-based backtracking.
+    stack: list[tuple[int, int]] = [(current_row, current_col)]
+
+    while stack:
+        current_row, current_col = stack[-1]
+        current_cell = grid[current_row][current_col]
+
+        neighbors = _unvisited_neighbors(grid, current_row, current_col)
+
+        if neighbors:
+            # Select random unvisited neighbor and carve passage.
+            next_row, next_col, direction = rng.choice(neighbors)
+            next_cell = grid[next_row][next_col]
+
+            _remove_wall_between(current_cell, next_cell, direction)
+            next_cell.visited = True
+            stack.append((next_row, next_col))
+        else:
+            # Backtrack when dead-end is reached.
+            stack.pop()
+
+    return grid
+
+
+def maze_to_wall_matrix(grid: Grid) -> list[list[dict[str, bool]]]:
+    """Convert maze cells to a serializable walls matrix."""
+
+    return [
+        [
+            {
+                "top": cell.top,
+                "right": cell.right,
+                "bottom": cell.bottom,
+                "left": cell.left,
+                "visited": cell.visited,
+            }
+            for cell in row
+        ]
+        for row in grid
+    ]
+
+
+if __name__ == "__main__":
+    sample_grid = generate_maze(rows=4, cols=6, seed=42)
+    for line in maze_to_wall_matrix(sample_grid):
+        print(line)

--- a/playable_maze.py
+++ b/playable_maze.py
@@ -1,0 +1,131 @@
+"""Terminal-playable maze game built on top of the DFS maze generator."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+from maze_generator import Grid, generate_maze
+
+
+@dataclass
+class Position:
+    row: int
+    col: int
+
+
+def _can_move(grid: Grid, pos: Position, direction: str) -> bool:
+    cell = grid[pos.row][pos.col]
+    if direction == "w":
+        return not cell.top
+    if direction == "d":
+        return not cell.right
+    if direction == "s":
+        return not cell.bottom
+    if direction == "a":
+        return not cell.left
+    return False
+
+
+def _apply_move(pos: Position, direction: str) -> Position:
+    if direction == "w":
+        return Position(pos.row - 1, pos.col)
+    if direction == "d":
+        return Position(pos.row, pos.col + 1)
+    if direction == "s":
+        return Position(pos.row + 1, pos.col)
+    if direction == "a":
+        return Position(pos.row, pos.col - 1)
+    return pos
+
+
+def _render_ascii(grid: Grid, player: Position, goal: Position) -> str:
+    """Render the maze as ASCII art with player/goal markers."""
+
+    rows = len(grid)
+    cols = len(grid[0])
+    lines: list[str] = []
+
+    # Top border
+    top = "+"
+    for c in range(cols):
+        top += ("---" if grid[0][c].top else "   ") + "+"
+    lines.append(top)
+
+    for r in range(rows):
+        mid = "|"
+        bottom = "+"
+
+        for c in range(cols):
+            marker = " "
+            if player.row == r and player.col == c:
+                marker = "P"
+            elif goal.row == r and goal.col == c:
+                marker = "G"
+
+            cell = grid[r][c]
+            right_wall = "|" if cell.right else " "
+            mid += f" {marker} {right_wall}"
+            bottom += ("---" if cell.bottom else "   ") + "+"
+
+        lines.append(mid)
+        lines.append(bottom)
+
+    return "\n".join(lines)
+
+
+def _normalize_command(raw: str) -> str:
+    value = raw.strip().lower()
+    if value in {"up", "w"}:
+        return "w"
+    if value in {"right", "d"}:
+        return "d"
+    if value in {"down", "s"}:
+        return "s"
+    if value in {"left", "a"}:
+        return "a"
+    return value
+
+
+def _iter_moves() -> Iterable[str]:
+    while True:
+        yield input("Move (W/A/S/D, or Q to quit): ")
+
+
+def play(rows: int = 10, cols: int = 20, seed: int | None = None) -> None:
+    if rows <= 0 or cols <= 0:
+        raise ValueError("rows and cols must both be > 0")
+
+    grid = generate_maze(rows=rows, cols=cols, seed=seed)
+    player = Position(0, 0)
+    goal = Position(rows - 1, cols - 1)
+    moves = 0
+
+    print("Reach G from P. You can move using W/A/S/D.")
+
+    for raw in _iter_moves():
+        print(_render_ascii(grid, player, goal))
+
+        command = _normalize_command(raw)
+        if command in {"q", "quit", "exit"}:
+            print("Game ended.")
+            return
+
+        if command not in {"w", "a", "s", "d"}:
+            print("Invalid move. Use W/A/S/D.")
+            continue
+
+        if _can_move(grid, player, command):
+            player = _apply_move(player, command)
+            moves += 1
+        else:
+            print("Blocked by a wall.")
+
+        if player == goal:
+            print(_render_ascii(grid, player, goal))
+            print(f"You solved the maze in {moves} moves! 🎉")
+            return
+
+
+if __name__ == "__main__":
+    play()


### PR DESCRIPTION
### Motivation
- Provide a standalone depth-first search maze generator that represents cells with explicit walls and visited flags and produces a serializable wall matrix. 
- Offer an interactive, terminal-playable experience so users can explore generated mazes with keyboard controls. 

### Description
- Added `maze_generator.py` which implements a `Cell` dataclass, `_unvisited_neighbors`, `_remove_wall_between`, `generate_maze(rows, cols, seed)` using stack-based DFS, and `maze_to_wall_matrix` for serialization. 
- Added `playable_maze.py` which renders mazes as ASCII with `P` (player) and `G` (goal), supports movement via `W/A/S/D` (and `up/right/down/left` aliases), enforces wall collisions, and detects win/quit conditions. 
- Updated `README.md` with usage instructions for generating wall data and running the terminal-playable mode, including controls and goal description. 

### Testing
- Ran `python maze_generator.py | head` to generate sample wall output and inspected the printed matrix, which completed successfully. 
- Ran `printf 'q\n' | python playable_maze.py | head -n 20` to exercise startup and ASCII rendering of the playable script, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bb835f334833387fb0bfcc6d26823)